### PR TITLE
Adding a 'g:clojure_no_default_key_mapping' variable

### DIFF
--- a/doc/clojure.txt
+++ b/doc/clojure.txt
@@ -238,6 +238,13 @@ turned off.
                         of the buffer. This modifies the way the form is
                         indented.
 
+                                                *g:clojure_no_default_key_mappings*
+
+You may remove the mapping of the default keybindings by setting the variable
+>
+        g:clojure_no_default_key_mappings = 1
+<
+
 Vim Repl
 --------
 

--- a/ftplugin/clojure.vim
+++ b/ftplugin/clojure.vim
@@ -4,7 +4,7 @@
 
 " Only do this when not done yet for this buffer
 if exists("b:did_ftplugin")
-	finish
+  finish
 endif
 
 let b:did_ftplugin = 1
@@ -29,12 +29,12 @@ setlocal comments=sO:;\ -,mO:;\ \ ,n:;
 " Take all directories of the CLOJURE_SOURCE_DIRS environment variable
 " and add them to the path option.
 if has("win32") || has("win64")
-	let s:delim = ";"
+  let s:delim = ";"
 else
-	let s:delim = ":"
+  let s:delim = ":"
 endif
 for dir in split($CLOJURE_SOURCE_DIRS, s:delim)
-	call vimclojure#AddPathToOption(dir . "/**", 'path')
+  call vimclojure#AddPathToOption(dir . "/**", 'path')
 endfor
 
 " When the matchit plugin is loaded, this makes the % command skip parens and
@@ -44,61 +44,62 @@ let b:match_skip = 's:comment\|string\|character'
 
 " Win32 can filter files in the browse dialog
 if has("gui_win32") && !exists("b:browsefilter")
-	let b:browsefilter = "Clojure Source Files (*.clj)\t*.clj\n" .
-				\ "Jave Source Files (*.java)\t*.java\n" .
-				\ "All Files (*.*)\t*.*\n"
+  let b:browsefilter = "Clojure Source Files (*.clj)\t*.clj\n" .
+        \ "Jave Source Files (*.java)\t*.java\n" .
+        \ "All Files (*.*)\t*.*\n"
 endif
 
 for ns in [ "clojure.core", "clojure.inspector", "clojure.java.browse",
-			\ "clojure.java.io", "clojure.java.javadoc", "clojure.java.shell",
-			\ "clojure.main", "clojure.pprint", "clojure.repl", "clojure.set",
-			\ "clojure.stacktrace", "clojure.string", "clojure.template",
-			\ "clojure.test", "clojure.test.tap", "clojure.test.junit",
-			\ "clojure.walk", "clojure.xml", "clojure.zip" ]
-	call vimclojure#AddCompletions(ns)
+      \ "clojure.java.io", "clojure.java.javadoc", "clojure.java.shell",
+      \ "clojure.main", "clojure.pprint", "clojure.repl", "clojure.set",
+      \ "clojure.stacktrace", "clojure.string", "clojure.template",
+      \ "clojure.test", "clojure.test.tap", "clojure.test.junit",
+      \ "clojure.walk", "clojure.xml", "clojure.zip" ]
+  call vimclojure#AddCompletions(ns)
 endfor
 
 " Define toplevel folding if desired.
 function! ClojureGetFoldingLevel(lineno)
-	let closure = { 'lineno' : a:lineno }
+  let closure = { 'lineno' : a:lineno }
 
-	function closure.f() dict
-		execute self.lineno
+  function closure.f() dict
+    execute self.lineno
 
-		if vimclojure#SynIdName() =~ 'clojureParen\d' && vimclojure#Yank('l', 'normal! "lyl') == '('
-			return 1
-		endif
+    if vimclojure#SynIdName() =~ 'clojureParen\d' && vimclojure#Yank('l', 'normal! "lyl') == '('
+      return 1
+    endif
 
-		if searchpairpos('(', '', ')', 'bWr', 'vimclojure#SynIdName() !~ "clojureParen\\d"') != [0, 0]
-			return 1
-		endif
+    if searchpairpos('(', '', ')', 'bWr', 'vimclojure#SynIdName() !~ "clojureParen\\d"') != [0, 0]
+      return 1
+    endif
 
-		return 0
-	endfunction
+    return 0
+  endfunction
 
-	return vimclojure#WithSavedPosition(closure)
+  return vimclojure#WithSavedPosition(closure)
 endfunction
 
 " Disabled for now. Too slow (and naive).
 if exists("g:clj_want_folding") && g:clj_want_folding == 1 && 0 == 1
-	setlocal foldexpr=ClojureGetFoldingLevel(v:lnum)
-	setlocal foldmethod=expr
+  setlocal foldexpr=ClojureGetFoldingLevel(v:lnum)
+  setlocal foldmethod=expr
 endif
 
 try
-	call vimclojure#InitBuffer()
+  call vimclojure#InitBuffer()
 catch /.*/
-	" We swallow a failure here. It means most likely that the
-	" server is not running.
-	echohl WarningMsg
-	echomsg v:exception
-	echohl None
+  " We swallow a failure here. It means most likely that the
+  " server is not running.
+  echohl WarningMsg
+  echomsg v:exception
+  echohl None
 endtry
 
-if !exists('g:clojure_no_default_key_mappings') ||
-    \ ((exists('g:clojure_no_default_key_mappings') &&
-    \ !g:clojure_no_default_key_mappings))
+if !exists('g:vimclojure_no_default_key_mappings') ||
+    \ ((exists('g:vimclojure_no_default_key_mappings') &&
+    \ !g:vimclojure_no_default_key_mappings))
 
+  echom "Hey I'm getting in"
   call vimclojure#MapPlug("n", "aw", "AddToLispWords")
 
   call vimclojure#MapCommandPlug("n", "lw", "DocLookupWord")
@@ -138,11 +139,11 @@ if !exists('g:clojure_no_default_key_mappings') ||
 endif
 
 if exists("b:vimclojure_namespace")
-	setlocal omnifunc=vimclojure#OmniCompletion
+  setlocal omnifunc=vimclojure#OmniCompletion
 
-	augroup VimClojure
-		autocmd CursorMovedI <buffer> if pumvisible() == 0 | pclose | endif
-	augroup END
+  augroup VimClojure
+    autocmd CursorMovedI <buffer> if pumvisible() == 0 | pclose | endif
+  augroup END
 endif
 
 

--- a/ftplugin/clojure.vim
+++ b/ftplugin/clojure.vim
@@ -95,39 +95,47 @@ catch /.*/
 	echohl None
 endtry
 
-call vimclojure#MapPlug("n", "aw", "AddToLispWords")
+if !exists('g:clojure_no_default_key_mappings') ||
+    \ ((exists('g:clojure_no_default_key_mappings') &&
+    \ !g:clojure_no_default_key_mappings))
 
-call vimclojure#MapCommandPlug("n", "lw", "DocLookupWord")
-call vimclojure#MapCommandPlug("n", "li", "DocLookupInteractive")
-call vimclojure#MapCommandPlug("n", "jw", "JavadocLookupWord")
-call vimclojure#MapCommandPlug("n", "ji", "JavadocLookupInteractive")
-call vimclojure#MapCommandPlug("n", "fd", "FindDoc")
+  call vimclojure#MapPlug("n", "aw", "AddToLispWords")
 
-call vimclojure#MapCommandPlug("n", "mw", "MetaLookupWord")
-call vimclojure#MapCommandPlug("n", "mi", "MetaLookupInteractive")
+  call vimclojure#MapCommandPlug("n", "lw", "DocLookupWord")
+  call vimclojure#MapCommandPlug("n", "li", "DocLookupInteractive")
+  call vimclojure#MapCommandPlug("n", "jw", "JavadocLookupWord")
+  call vimclojure#MapCommandPlug("n", "ji", "JavadocLookupInteractive")
+  call vimclojure#MapCommandPlug("n", "fd", "FindDoc")
 
-call vimclojure#MapCommandPlug("n", "sw", "SourceLookupWord")
-call vimclojure#MapCommandPlug("n", "si", "SourceLookupInteractive")
+  call vimclojure#MapCommandPlug("n", "mw", "MetaLookupWord")
+  call vimclojure#MapCommandPlug("n", "mi", "MetaLookupInteractive")
 
-call vimclojure#MapCommandPlug("n", "gw", "GotoSourceWord")
-call vimclojure#MapCommandPlug("n", "gi", "GotoSourceInteractive")
+  call vimclojure#MapCommandPlug("n", "sw", "SourceLookupWord")
+  call vimclojure#MapCommandPlug("n", "si", "SourceLookupInteractive")
 
-call vimclojure#MapCommandPlug("n", "rf", "RequireFile")
-call vimclojure#MapCommandPlug("n", "rF", "RequireFileAll")
+  call vimclojure#MapCommandPlug("n", "gw", "GotoSourceWord")
+  call vimclojure#MapCommandPlug("n", "gi", "GotoSourceInteractive")
 
-call vimclojure#MapCommandPlug("n", "rt", "RunTests")
+  call vimclojure#MapCommandPlug("n", "rf", "RequireFile")
+  call vimclojure#MapCommandPlug("n", "rF", "RequireFileAll")
 
-call vimclojure#MapCommandPlug("n", "me", "MacroExpand")
-call vimclojure#MapCommandPlug("n", "m1", "MacroExpand1")
+  call vimclojure#MapCommandPlug("n", "rt", "RunTests")
 
-call vimclojure#MapCommandPlug("n", "ef", "EvalFile")
-call vimclojure#MapCommandPlug("n", "el", "EvalLine")
-call vimclojure#MapCommandPlug("v", "eb", "EvalBlock")
-call vimclojure#MapCommandPlug("n", "et", "EvalToplevel")
-call vimclojure#MapCommandPlug("n", "ep", "EvalParagraph")
+  call vimclojure#MapCommandPlug("n", "me", "MacroExpand")
+  call vimclojure#MapCommandPlug("n", "m1", "MacroExpand1")
 
-call vimclojure#MapCommandPlug("n", "sr", "StartRepl")
-call vimclojure#MapCommandPlug("n", "sR", "StartLocalRepl")
+  call vimclojure#MapCommandPlug("n", "ef", "EvalFile")
+  call vimclojure#MapCommandPlug("n", "el", "EvalLine")
+  call vimclojure#MapCommandPlug("v", "eb", "EvalBlock")
+  call vimclojure#MapCommandPlug("n", "et", "EvalToplevel")
+  call vimclojure#MapCommandPlug("n", "ep", "EvalParagraph")
+
+  call vimclojure#MapCommandPlug("n", "sr", "StartRepl")
+  call vimclojure#MapCommandPlug("n", "sR", "StartLocalRepl")
+
+  call vimclojure#MapPlug("n", "p", "CloseResultBuffer")
+
+endif
 
 if exists("b:vimclojure_namespace")
 	setlocal omnifunc=vimclojure#OmniCompletion
@@ -137,6 +145,5 @@ if exists("b:vimclojure_namespace")
 	augroup END
 endif
 
-call vimclojure#MapPlug("n", "p", "CloseResultBuffer")
 
 let &cpo = s:cpo_save


### PR DESCRIPTION
This way avoiding clashes with existing key-mappings by letting the developer can choose to add them or not to his vim environment.
