### PR TITLE
Added crude Clojurescript

### DIFF
--- a/ftdetect/clojure.vim
+++ b/ftdetect/clojure.vim
@@ -1,1 +1,2 @@
 au BufNewFile,BufRead *.clj set filetype=clojure
+au BufNewFile,BufRead *.cljs set filetype=clojure


### PR DESCRIPTION
Hi,
I edited the ftdetect file to add crude support for Clojurescript.  My main goal was simply to enable syntax highlighting on .cljs files.  I tested it on my local machine, and it seemed to work just fine.  Would love to see this added to the plugin.

Thanks for providing it,
Sean Devlin
