### PR TITLE
Fix EvalParagraph to collect all paragraph lines

### DIFF
--- a/autoload/vimclojure.vim
+++ b/autoload/vimclojure.vim
@@ -685,7 +685,7 @@ endfunction
 function! vimclojure#EvalParagraph()
 	let file = vimclojure#BufferName()
 	let ns = b:vimclojure_namespace
-	let startPosition = line(".")
+	let startPosition = line("'{")
 
 	let closure = { 'f' : function("ClojureEvalParagraphWorker") }
 


### PR DESCRIPTION
Regardless of where you are in the paragraph, EvalParagraph
will collect all lines in the paragraph for evaluation.
